### PR TITLE
Fixing README to update standard file validation hook names

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ repos:
     rev: v4.4.0
     hooks:
       # Standard file validation
-      - id: check_yaml
-      - id: check_json
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### 3. Install the hooks
@@ -212,10 +212,10 @@ repos:
     rev: v4.4.0
     hooks:
       # File Validation
-      - id: check_yaml
-      - id: check_json
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### Node.js/React Project
@@ -240,10 +240,10 @@ repos:
     rev: v4.4.0
     hooks:
       # File Validation
-      - id: check_json
-      - id: check_yaml
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-json
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### Java Project
@@ -270,9 +270,9 @@ repos:
     rev: v4.4.0
     hooks:
       # Standard File Validation
-      - id: check_yaml
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### .NET Project
@@ -296,10 +296,10 @@ repos:
     rev: v4.4.0
     hooks:
       # File Validation
-      - id: check_yaml
-      - id: check_json
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### Go Project
@@ -323,10 +323,10 @@ repos:
     rev: v4.4.0
     hooks:
       # File Validation
-      - id: check_yaml
-      - id: check_json
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### Ansible Project
@@ -350,9 +350,9 @@ repos:
     rev: v4.4.0
     hooks:
       # File Validation
-      - id: check_yaml
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
 ```
 
 ### Infrastructure as Code
@@ -378,9 +378,9 @@ repos:
     rev: v4.4.0
     hooks:
       # File Validation
-      - id: check_yaml
-      - id: check_json
-      - id: trailing_whitespace
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
 ```
 
 ### Full Stack Project
@@ -441,11 +441,11 @@ repos:
     rev: v4.4.0
     hooks:
       # Standard File Validation
-      - id: check_yaml
-      - id: check_json
-      - id: trailing_whitespace
-      - id: end_of_file_fixer
-      - id: check_added_large_files
+      - id: check-yaml
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
 ```
 
 ## 🎛️ Hook Configuration


### PR DESCRIPTION
For the standard file validation checks from the https://github.com/pre-commit/pre-commit-hooks repository, the hook names use dashes instead of underscores in the name. 

With underscores:

```
❯ pre-commit run --all-files
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[ERROR] `check_yaml` is not present in repository https://github.com/pre-commit/pre-commit-hooks.  Typo? Perhaps it is introduced in a newer version?  Often `pre-commit autoupdate` fixes this.

> pre-commit autoupdate
[https://github.com/TriaFed/pre-commit-library] already up to date!
[https://github.com/pre-commit/pre-commit-hooks] Cannot update because the update target is missing these hooks: check_json, check_yaml, end_of_file_fixer, trailing_whitespace
```

With dashes, it works as expected.