### PR TITLE
Hook fixes

### DIFF
--- a/hooks/detect_hardcoded_urls.py
+++ b/hooks/detect_hardcoded_urls.py
@@ -35,6 +35,7 @@ SAFE_URL_PATTERNS = [
     r'https?://.*\.test',
     r'https?://.*\.local',
     r'https?://.*\.localhost',
+    r'https?://mock-host/.*?',
     # Common documentation URLs
     r'https?://(?:www\.)?github\.com(?:/.*)?',
     r'https?://docs\..*',

--- a/hooks/detect_hardcoded_urls.py
+++ b/hooks/detect_hardcoded_urls.py
@@ -17,8 +17,10 @@ URL_PATTERNS = [
     r'ftp://[^\s\'">\]]+',
     # Database connection strings with URLs
     r'(?:jdbc|mongodb|mysql|postgresql)://[^\s\'">\]]+',
-    # API endpoints patterns
-    r'(?:api\.|www\.)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s\'">\]]*)?',
+    # API endpoints patterns (more specific to avoid overlap with documentation URLs)
+    r'api\.[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s\'">\]]*)?',
+    # Suspicious www domains (exclude common safe ones)
+    r'www\.(?!(?:w3\.org|github\.com|docs\.|example\.(?:com|org|net)|.*\.example\.(?:com|org|net)))[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s\'">\]]*)?',
 ]
 
 # URLs that are typically safe to ignore
@@ -34,10 +36,10 @@ SAFE_URL_PATTERNS = [
     r'https?://.*\.local',
     r'https?://.*\.localhost',
     # Common documentation URLs
-    r'https?://github\.com/.*',
+    r'https?://(?:www\.)?github\.com(?:/.*)?',
     r'https?://docs\..*',
-    r'https?://www\.w3\.org/.*',
-    r'https?://tools\.ietf\.org/.*',
+    r'https?://www\.w3\.org(?:/.*)?',
+    r'https?://tools\.ietf\.org(?:/.*)?',
     r'https?://schemas\..*',
     # Package registries
     r'https?://registry\.npmjs\.org/.*',
@@ -46,7 +48,7 @@ SAFE_URL_PATTERNS = [
 ]
 
 # File extensions to skip
-SKIP_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.ico', '.svg', '.pdf', '.zip', '.tar', '.gz'}
+SKIP_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.ico', '.svg', '.pdf', '.zip', '.tar', '.gz' '.md'}
 
 # Patterns that suggest this might be in a comment or documentation
 COMMENT_PATTERNS = [
@@ -65,7 +67,7 @@ def is_in_comment(line: str) -> bool:
 
 def is_safe_url(url: str) -> bool:
     """Check if URL matches safe patterns."""
-    return any(re.match(pattern, url, re.IGNORECASE) for pattern in SAFE_URL_PATTERNS)
+    return any(re.fullmatch(pattern, url, re.IGNORECASE) for pattern in SAFE_URL_PATTERNS)
 
 
 def find_hardcoded_urls(file_path: str) -> List[Tuple[int, str, str]]:

--- a/hooks/genai_security_check.py
+++ b/hooks/genai_security_check.py
@@ -216,8 +216,29 @@ def check_genai_patterns(file_path: str) -> List[Tuple[int, str, str, str]]:
                 if not line.strip():
                     continue
                 
+                # Check if line is an import statement
+                stripped_line = line.strip()
+                is_import_line = (
+                    stripped_line.startswith('import ') or
+                    stripped_line.startswith('from ') or
+                    re.match(r'^\s*import\s+', line) or
+                    re.match(r'^\s*from\s+', line) or
+                    re.match(r'^\s*#include\s*<', line) or  # C/C++
+                    re.match(r'^\s*#include\s*"', line) or  # C/C++
+                    re.match(r'^\s*using\s+', line) or     # C#/Java
+                    re.match(r'^\s*require\s*\(', line) or # JavaScript/Node.js
+                    re.match(r'^\s*const\s+.*\s*=\s*require\s*\(', line) or  # JavaScript/Node.js
+                    re.match(r'^\s*let\s+.*\s*=\s*require\s*\(', line) or    # JavaScript/Node.js
+                    re.match(r'^\s*var\s+.*\s*=\s*require\s*\(', line) or    # JavaScript/Node.js
+                    re.match(r'^\s*import\s+.*\s+from\s+', line)  # ES6 imports
+                )
+                
                 # Check security patterns
                 for pattern_name, pattern_info in GENAI_SECURITY_PATTERNS.items():
+                    # Skip path traversal checks for import lines
+                    if pattern_name == 'path_traversal' and is_import_line:
+                        continue
+                        
                     for pattern in pattern_info['patterns']:
                         if re.search(pattern, line, re.IGNORECASE):
                             issues.append((

--- a/hooks/genai_security_check.py
+++ b/hooks/genai_security_check.py
@@ -59,10 +59,10 @@ GENAI_SECURITY_PATTERNS = {
     },
     'weak_crypto': {
         'patterns': [
-            r'MD5',
-            r'SHA1\b',
-            r'DES\b',
-            r'RC4',
+            r'\bMD5\b',
+            r'\bSHA1\b',
+            r'\bDES\b',
+            r'\bRC4\b',
             r'\.md5\(',
             r'\.sha1\(',
             r'createHash\(["\']md5["\']',
@@ -220,9 +220,9 @@ def check_genai_patterns(file_path: str) -> List[Tuple[int, str, str, str]]:
                 stripped_line = line.strip()
                 is_import_line = (
                     stripped_line.startswith('import ') or
-                    stripped_line.startswith('from ') or
+                    stripp*ed_line.startswith('from ') or
                     re.match(r'^\s*import\s+', line) or
-                    re.match(r'^\s*from\s+', line) or
+                    re.match(r'^\s*}?\s*from\s+', line) or
                     re.match(r'^\s*#include\s*<', line) or  # C/C++
                     re.match(r'^\s*#include\s*"', line) or  # C/C++
                     re.match(r'^\s*using\s+', line) or     # C#/Java


### PR DESCRIPTION
Path Traversal:  Things were being flagged as path traversal issues when the relative path was part of an import or from statement. Fixed.

SAFE_URL_PATTERNS:  Everything in SAFE_URL_PATTERNS was being flagged despite being in the "SAFE" regex, because they all still matched one of the bad regexes.  Fixed.

mock-host added as a "SAFE" url because WaaS MEA uses it extensively in tests.

